### PR TITLE
Add implementation of Huffman decompression

### DIFF
--- a/src/huff.md
+++ b/src/huff.md
@@ -1,0 +1,120 @@
+# Decompressing Huffman Records in Mobi Files #
+
+Bit and byte indexes begin at zero, and refer to the most significant bit or byte first. Mobipocket files, and all values stored internally, are stored in big endian format. 
+
+For instance, bit 0 of 0b10 refers to 1, and bit 1 refers to 0. Byte 0 of 0xF0 refers to F, and byte 1 refers to 0.
+
+## Huffman Table  ##
+The Huffman table consists of the following:
+1. **Huffman Dictionary**: A mapping of indices to slices of compressed or decompressed bytes
+2. **Code Dictionary**: A fixed size mapping from all 8 bit values (0 to 255), to a 3-tuple consisting of a code length which can be a value from 1 to 31, inclusive, a boolean term, and a maximum code, which is an unsigned 32 bit value
+3. **Minimum and Maximum Codes**: A mapping from values 1 to 31, inclusive, to an unsigned 32 bit minimum code, and an unsigned 32 bit maximum code 
+
+Its structure in file is:
+- bytes 0-4: "HUFF" as utf8 bytes
+- bytes 4-8: 0x00_00_00_18
+- bytes 8-12: Offset to the **code dictionary (2.)**
+- bytes 12-16: Offset to **minimum and maximum codes (3.)**
+
+When parsing the individual records, the first record refers to this Huffman table, and all other records are CDIC records.
+
+### Code Dictionary
+The code dictionary consists of 256 distinct values, each 4 bytes in length, starting at the specified offset. The 3-tuples are indexed, starting from 0, in order of appearance.
+
+Each value is as follows:
+- bits 0-24: A value which represents the maximum code
+- bit 24: A boolean flag
+- bits 25-27: Unknown
+- bits 27-32: A code length
+
+The code length must not be zero, and the maximum possible code length is 31. 
+
+If the code length is 8 or less, the boolean flag must be set.
+
+The maximum code is derived as follows:
+``` ((max_code_value + 1) << (32 - code_length)) - 1 ```
+
+### Minimum and Maximum Codes
+The code dictionary consists of 32 pairs of minimum and maximum codes, with each pair being 8 bytes.
+In each pair, the minimum code representation appears in the four most significant bytes, and the maximum code representation appears in the four least significant bytes. 
+
+The values are indexed, starting from 1, in order of appearance. This index can be thought of as the code length.
+
+The minimum code is derived as follows:
+``` min_code_value << (32 - index) ```
+
+The maximum code is derived as follows:
+``` ((max_code_value + 1) << (32 - index)) - 1 ```
+
+Note that since the maximum code is 32 bits, the last minimum code is 0, and the last maximum code is 0xFFFF_FFFF.
+
+### Huffman Dictionary
+The dictionary is initialized by individually collecting the byte slices from all CDIC records in order of appearance.
+
+#### CDIC Record
+When reading CDIC records, the dictionary must also be provided.
+
+A CDIC record is stored as follows:
+- bytes 0-4: "CDIC" as utf8 bytes
+- bytes 4-8: 0x00_00_00_10
+- bytes 8-12: The number of "phrases"
+- bytes 12-16: A value used to calculate the maximum number of phrases.
+
+To determine the number of slices available in the record, use the following calculation:
+
+```n = minimum(pow(2, max_number_of_phrases), num_phrases - size(dictionary))```
+
+Starting at byte 16, **n** 16 bit offsets, (with respect to the start of the CDIC record) are available.
+
+The first two bytes at a given offset refer to a flag and a length, as follows:
+- bit 0: The compression flag.
+- bits 1-16: The slice length in number of bytes.
+
+If the compression flag is set, the slice will require decompression later. Otherwise, it can be used verbatim. The slice starts at the third byte, immediately after the flag and length, and is **length** bytes long.
+
+## Decompression
+When decompressing, the size of the Huffman dictionary does not change, but individual slices may be decompressed. 
+
+The procedure to decompress either data or internal byte slices is as follows:
+```
+fn decompress(data: Bytes, *) -> Result<Bytes, Error> {
+    data_bits <- data as bits
+    bit_index <- 0
+    decompressed <- []
+    
+    while bit_index < size(data_bits) {
+        code <- data_bits[bit_index..bit_index+32]
+        
+        (code_length, term, maximum_code) <- code_dictionary[code[0..8]]
+    
+        if not term {
+            # code_length will always exist, since the last minimum_code is 0.
+            code_length <- code_length + index(
+                minimum_codes[code_length..],
+                fn cmp(minimum_code) { code >= minimum_code }
+            )
+            maximum_code <- maximum_codes[code_length]
+        }
+        
+        index <- (maximum_code - code)[0..code_length]
+        if not exists(huffman_dictionary[index]) {
+            return InvalidIndex;
+        }
+        
+        slice <- huffman_dictionary[index]
+        
+        if compressed(slice) {
+            pop(huffman_dictionary[index])
+            slice <- decompress(slice, *)
+            insert(huffman_dictionary, index, slice)
+        }
+        
+        decompressed <- decompressed + slice
+        
+        bit_index <- bit_index + code_length
+    }
+    
+    decompressed
+}
+```
+Note that indexing into data_bits is done from most significant to least significant bit (and if a given bit index is not available, it should be substituted with zeros), and that * refers to all values which appear in the function body, but are not explicitly passed in (refer to previous sections to find what these values refer to).

--- a/src/huff.rs
+++ b/src/huff.rs
@@ -1,0 +1,184 @@
+use crate::Reader;
+
+type HuffmanResult<T> = Result<T, HuffmanError>;
+
+pub enum HuffmanError {
+    IoError(std::io::Error),
+    CodeLenOutOfBounds,
+    BadTerm,
+    InvalidHuffHeader,
+    InvalidCDICHeader,
+    InvalidDictionaryIndex,
+}
+
+impl From<std::io::Error> for HuffmanError {
+    fn from(e: std::io::Error) -> Self {
+        Self::IoError(e)
+    }
+}
+
+struct HuffmanDecoder {
+    dictionary: Vec<Option<(Vec<u8>, bool)>>,
+    code_dict: [(u8, bool, u32); 256],
+    min_codes: [u32; 33],
+    max_codes: [u32; 33],
+}
+
+fn load_huff(huff: &[u8]) -> HuffmanResult<([(u8, bool, u32); 256], [u32; 32], [u32; 33])> {
+    let mut r = Reader::new(std::io::Cursor::new(huff));
+
+    if r.read_u32_be()? != u32::from_be_bytes(*b"HUFF") || r.read_u32_be()? != 0x18 {
+        return Err(HuffmanError::InvalidHuffHeader);
+    }
+
+    let off1 = r.read_u32_be()?;
+    let off2 = r.read_u32_be()?;
+
+    r.set_position(off1 as usize)?;
+
+    let mut code_dict = [(0, false, 0); 256];
+    for code in code_dict.iter_mut() {
+        let v = r.read_u32_be()?;
+        // 0 < code_len <= 32, term is T or F, max_code is u24 pretending to be u32.
+        let (code_len, term, mut max_code) = ((v & 0x1F) as u8, (v & 0x80) == 0x80, v >> 8);
+        if code_len == 0 {
+            return Err(HuffmanError::CodeLenOutOfBounds);
+        }
+        if code_len <= 8 && !term {
+            return Err(HuffmanError::BadTerm);
+        }
+        max_code = ((max_code + 1) << (32 - code_len)) - 1;
+        *code = (code_len, term, max_code);
+    }
+
+    r.set_position(off2 as usize)?;
+
+    // First value is ignored, since code_len > 0.
+    let mut min_codes = [0; 33];
+    let mut max_codes = [u32::max_value(); 33];
+
+    // Fill all other values.
+    for code_len in 1..=32 {
+        min_codes[code_len] = r.read_u32_be()? << (32 - code_len);
+        max_codes[code_len] = ((r.read_u32_be()? + 1) << (32 - code_len)).wrapping_sub(1);
+    }
+
+    Ok((code_dict, min_codes, max_codes))
+}
+
+fn load_cdic(cdic: &[u8], dictionary: &mut Vec<Option<(Vec<u8>, bool)>>) -> HuffmanResult<()> {
+    let mut r = Reader::new(std::io::Cursor::new(cdic));
+
+    if r.read_u32_be()? != u32::from_be_bytes(*b"CDIC") || r.read_u32_be()? != 0x10 {
+        return Err(HuffmanError::InvalidCDICHeader);
+    }
+
+    let num_phrases = r.read_u32_be()?;
+    let bits = r.read_u32_be()?;
+
+    let n = (1 << bits).min(num_phrases - dictionary.len() as u32);
+
+    let mut offsets = Vec::with_capacity(n as usize);
+    for _ in 0..n {
+        offsets.push(r.read_u16_be()?);
+    }
+
+    for offset in offsets {
+        r.set_position(16 + offset as usize)?;
+        let num_bytes = r.read_u16_be()?;
+        let bytes = {
+            let mut slice = vec![0; (num_bytes as usize) & 0x7FFF];
+            r.read_exact(&mut slice)?;
+            slice
+        };
+        dictionary.push(Some((bytes, (num_bytes & 0x8000) == 0x8000)));
+    }
+
+    Ok(())
+}
+
+fn unpack(
+    data: &[u8],
+    dictionary: &mut [Option<(Vec<u8>, bool)>],
+    code_dict: &[(u8, bool, u32); 256],
+    min_codes: &[u32; 33],
+    max_codes: &[u32; 33],
+) -> HuffmanResult<Vec<u8>> {
+    // Need len.
+    let mut bits_left = data.len() * 8;
+
+    let mut r = Reader::new(std::io::Cursor::new(&data));
+
+    // X is a sliding window of 64 bits from data.
+    let mut x = r.read_u64_be()?;
+    // -32 < n <= 32
+    let mut n = 32i8;
+    let mut unpacked = vec![];
+
+    loop {
+        // The top 32 bits are now stale, read next 32 bits.
+        if n <= 0 {
+            // Can not read another 32 bits.
+            if bits_left < 32 {
+                // Can read up to 3 bytes.
+                for _ in 0..bits_left / 8 {
+                    x = (x << 8) | u64::from(r.read_u8()?);
+                }
+                // Pad last bits with 0.
+                x <<= 32 - bits_left;
+            } else {
+                x = (x << 32) | u64::from(r.read_u32_be()?);
+            }
+            n += 32;
+        }
+
+        // Read maximum of 32 bits from x.
+        let code = (x >> n) as u32;
+        // Get value from dict1.
+        let (code_len, term, mut max_code) = code_dict[(code >> 24) as usize];
+
+        // 32 > code_len > 0.
+        let mut code_len = code_len as usize;
+        if !term {
+            // Last min_code is guaranteed to be 0, so no unwrap.
+            code_len += min_codes[code_len..]
+                .iter()
+                .position(|&min_code| code >= min_code)
+                .unwrap();
+            max_code = max_codes[code_len];
+        }
+
+        let index = ((max_code - code) >> (32 - code_len)) as usize;
+        let (mut slice, flag) = std::mem::take(dictionary.get_mut(index).ok_or(HuffmanError::InvalidDictionaryIndex)?)
+            .ok_or(HuffmanError::InvalidDictionaryIndex)?;
+        if !flag {
+            slice = unpack(&slice, dictionary, code_dict, min_codes, max_codes)?;
+        }
+        unpacked.extend_from_slice(&slice);
+        dictionary[index] = Some((slice, true));
+
+        // code_len <= 32, so this is safe.
+        n -= code_len as i8;
+        bits_left = match bits_left.checked_sub(code_len) {
+            // No more bits left to read.
+            None | Some(0) => break,
+            Some(i) => i,
+        };
+    }
+
+    Ok(unpacked)
+}
+
+fn decompress(huffs: &[&[u8]], sections: &[&[u8]]) -> HuffmanResult<Vec<Vec<u8>>> {
+    let (dict1, min_code, max_code) = load_huff(&huffs[0])?;
+    let mut dictionary = Vec::new();
+    for huff in huffs[1..].iter() {
+        load_cdic(huff, &mut dictionary)?;
+    }
+
+    let mut output = Vec::new();
+    for section in sections {
+        output.push(unpack(section, &mut dictionary, &dict1, &min_code, &max_code)?);
+    }
+    Ok(output)
+}


### PR DESCRIPTION
I noticed that there has been a request for huffman decompression. I implemented this a while ago, but I don't have any test data to verify that this implementation is correct - however, from my inspection of Calibre's implementation, I believe this should be correct.

Should resolve #27 